### PR TITLE
Fix/build with internals

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -24,12 +24,19 @@ check_for_go
 
 install_path="${INSTALL_PATH:-/shared/ucl/apps/cluster-bin}"
 
-echo "Changing into $(dirname -- "$0")..." >&2
+echo "Changing into \"$(dirname -- "$0")\"..." >&2
 cd "$(dirname -- "$0")"
 
 echo "Making temporary GOPATH..." >&2
 export GOPATH
 GOPATH="$(mktemp -t -d tmp-go-path.XXXXXXXX)"
+
+echo "Linking current directory to correct place in GOPATH..." >&2
+remote_url="$(git config --get remote.origin.url)"
+remote_url="${remote_url##https://}"
+dir_for_remote="${remote_url%/*}"
+mkdir -p "$GOPATH/src/$dir_for_remote"
+ln -s "$(pwd)" "$GOPATH/src/$dir_for_remote/"
 
 echo "Fetching dependencies..." >&2
 ./fetchdeps.sh

--- a/install.sh
+++ b/install.sh
@@ -42,7 +42,6 @@ else
 fi
 mkdir -p "$GOPATH/src/$dir_for_remote"
 ln -s "$(pwd)" "$GOPATH/src/$dir_for_remote/"
-echo "$GOPATH/src/$dir_for_remote"
 
 echo "Fetching dependencies..." >&2
 ./fetchdeps.sh

--- a/install.sh
+++ b/install.sh
@@ -33,10 +33,16 @@ GOPATH="$(mktemp -t -d tmp-go-path.XXXXXXXX)"
 
 echo "Linking current directory to correct place in GOPATH..." >&2
 remote_url="$(git config --get remote.origin.url)"
-remote_url="${remote_url##https://}"
-dir_for_remote="${remote_url%/*}"
+if [[ "${remote_url:0:4}" == "git@" ]]; then
+    remote_url="github.com/${remote_url#git@github.com:}"
+    dir_for_remote="${remote_url%/*}"
+else
+    remote_url="${remote_url##https://}"
+    dir_for_remote="${remote_url%/*}"
+fi
 mkdir -p "$GOPATH/src/$dir_for_remote"
 ln -s "$(pwd)" "$GOPATH/src/$dir_for_remote/"
+echo "$GOPATH/src/$dir_for_remote"
 
 echo "Fetching dependencies..." >&2
 ./fetchdeps.sh


### PR DESCRIPTION
Because we build inside a git checkout outside the GOPATH, we couldn't use a package structure inside our own repo.

This PR adds a step to the install where it symlinks the clone directory to the right place in the temporary GOPATH, allowing proper use of internals.