### PR TITLE
Adds dinf and the adhelper internal package

### DIFF
--- a/cmd/dinf/main.go
+++ b/cmd/dinf/main.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/UCL-RITS/go-clustertools/internal/adhelper"
+	"github.com/go-ldap/ldap/v3"
+	"gopkg.in/alecthomas/kingpin.v2"
+)
+
+var defaultPasswordFiles = []string{os.Getenv("DINF_ADPWFILE"), os.Getenv("HOME") + "/.adpw", "/shared/ucl/etc/adpw"}
+
+var description = `
+A program to quickly query Active Directory for user and group data.
+`
+
+var (
+	app = kingpin.New("dinf", description)
+
+	insecure    = app.Flag("insecure", "Insecurely ignore server certificate.").Short('i').Short('k').Bool()
+	searchField = app.Flag("search-field", "Field to search on. (e.g. mail, memberOf, sn)").Short('f').Default("CN").String()
+
+	ldapUrl       = app.Flag("server", "URL of the LDAP/AD server to connect to.").Short('s').Default("ldaps://ldap-auth-ad-slb.ucl.ac.uk:636/").String()
+	bindUser      = app.Flag("user", "User to authenticate to the server with. (\"Bind\" user.)").Short('u').Default(`AD\sa-ritsldap01`).String()
+	bindPassword  = app.Flag("password", "Password to authenticate to the server with. (\"Bind\" password.) If empty or not provided, files will be used.").Short('p').Default("").String()
+	bindCredsFile = app.Flag("creds-file", "File to get bind credentials from. (Default: first of $DINF_ADPWFILE ~/.adpw /shared/ucl/etc/adpw)").Short('c').PlaceHolder("file").String()
+	certFile      = app.Flag("cert", "Certificate to use with LDAPS. (Default: DINF_CERT)").PlaceHolder("file").Default("@").String() // @ is unset marker
+	searchBase    = app.Flag("base", "Search base in the LDAP tree.").Short('b').Default("DC=ad,DC=ucl,DC=ac,DC=uk").String()
+	returnFields  = app.Flag("output", "Command-separated fields to show in output. (Default: all)").Short('o').PlaceHolder("field[,field...]").String()
+
+	bareVals   = app.Flag("bare", "Just print the values, without field names, no DN object labels.").Default("false").Bool()
+	rawQuery  = app.Flag("raw", "Mandatory argument is a raw query, don't build a query yourself.").Default("false").Bool()
+	quietMode = app.Flag("quiet", "Don't print output, just return 0 if there are results or 1 if not.").Default("false").Bool()
+
+	searchTerm = app.Arg("search_term", "Search term (required).").Required().Strings()
+)
+
+func main() {
+	kingpin.MustParse(app.Parse(os.Args[1:]))
+
+	var realPassword string
+
+	if *bindPassword == "" {
+		if *bindCredsFile != "" {
+			realPassword = readPassword([]string{*bindCredsFile})
+		} else {
+			realPassword = readPassword(defaultPasswordFiles)
+		}
+	} else {
+		realPassword = *bindPassword
+	}
+
+	// Override env var with cli arg, or set to nil if neither
+	certFileEnv, certFileEnvIsSet := os.LookupEnv("DINF_CERTFILE")
+	if *certFile == "@" {
+		// @ here means it was not set by cli arg
+		if certFileEnvIsSet {
+			*certFile = certFileEnv
+		} else {
+			*certFile = ""
+		}
+	}
+
+	ldapOpts := adhelper.LdapOpts{
+		ServerUrl: *ldapUrl,
+		Username:  *bindUser,
+		Password:  realPassword,
+		BaseDN:    *searchBase,
+		Insecure:  *insecure,
+		CertFile:  *certFile,
+	}
+
+	splitReturnFields := strings.Split(*returnFields, ",")
+	if (len(splitReturnFields) == 1) && (splitReturnFields[0] == "") {
+		splitReturnFields = []string{}
+	}
+
+	var searchExpression string
+	if *rawQuery {
+		searchExpression = (*searchTerm)[0]
+	} else {
+		searchExpression = fmt.Sprintf("(%s=%s)", *searchField, (*searchTerm)[0])
+	}
+
+	result, err := adhelper.RunADSearch(&ldapOpts, searchExpression, splitReturnFields)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if *quietMode {
+		if len(result.Entries) == 0 {
+			os.Exit(1)
+		} else {
+			os.Exit(0)
+		}
+	}
+
+	if len(result.Entries) == 0 {
+		log.Fatalln("search result has no entries")
+	}
+
+	if *bareVals {
+		BarePrint(result)
+	} else {
+		PrettierPrint(result, 2)
+	}
+}
+
+// I abstracted the pretty-printing functions from the ldap package so I could alter the format.
+
+// PrettierPrint outputs a human-readable description with indenting
+func PrettierPrint(s *ldap.SearchResult, indent int) {
+	for _, entry := range s.Entries {
+		PrettierEPrint(entry, indent)
+	}
+}
+
+// PrettierPrint outputs a human-readable description with indenting
+func PrettierEAPrint(e *ldap.EntryAttribute, indent int) {
+	for _, v := range e.Values {
+		fmt.Printf("%s%s: %s\n", strings.Repeat(" ", indent), e.Name, filterPrintable(v))
+	}
+	//fmt.Printf("%s%s: %#v\n", strings.Repeat(" ", indent), e.Name, e.Values)
+}
+
+// PrettierPrint outputs a human-readable description indenting
+func PrettierEPrint(e *ldap.Entry, indent int) {
+	fmt.Printf("%sDN: %s\n", strings.Repeat(" ", indent), e.DN)
+	for _, attr := range e.Attributes {
+		PrettierEAPrint(attr, indent+2)
+	}
+}
+
+// Bare value output, for scripting
+func BarePrint(s *ldap.SearchResult) {
+	for _, entry := range s.Entries {
+		for _, attr := range entry.Attributes {
+			for _, v := range attr.Values {
+				fmt.Printf("%s\n", string(v))
+			}
+		}
+	}
+}

--- a/cmd/dinf/passwordfiles.go
+++ b/cmd/dinf/passwordfiles.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"errors"
+	"io/ioutil"
+	"log"
+	"os"
+	"strings"
+)
+
+func readPassword(possibleFilenames []string) string {
+	for _, filename := range possibleFilenames {
+		if filename == "" {
+			// Skip blank entry, for if e.g. env var is unset
+			continue
+		}
+		file, err := os.Open(filename)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			log.Fatal("Fatal error: file "+filename+" exists but could not be read: ", err)
+		}
+		defer file.Close()
+		fileContents, err := ioutil.ReadAll(file)
+		return strings.TrimSpace(string(fileContents))
+	}
+	log.Fatalf("No valid password file could be found from following files: " + strings.Join(possibleFilenames, " "))
+	return ""
+}

--- a/cmd/dinf/printable.go
+++ b/cmd/dinf/printable.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"strings"
+	"unicode"
+)
+
+func filterPrintable(s string) string {
+	return strings.Map(func(r rune) rune {
+		if unicode.IsPrint(r) {
+			return r
+		}
+		return -1
+	}, s)
+}

--- a/internal/adhelper/ad.go
+++ b/internal/adhelper/ad.go
@@ -1,0 +1,90 @@
+package adhelper
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+
+	"github.com/go-ldap/ldap/v3"
+)
+
+type LdapOpts struct {
+	ServerUrl string `yaml:"server_url"`
+	Username  string `yaml:"bind_username"`
+	Password  string `yaml:"bind_password"`
+	BaseDN    string `yaml:"base_dn"`
+	Insecure  bool   `yaml:"allow_insecure"`
+	CertFile  string `yaml:"cert_file"`
+}
+
+//var exampleLdapOpts = LdapOpts{
+//	ServerUrl: "ldaps://ad.example.com/",
+//	Username:  "AD\\user",
+//	Password:  "hunter2",
+//	BaseDN:    "DC=ad,DC=example,DC=com",
+//	Insecure:  true,
+//  CertFile:  ""
+//}
+
+func RunADSearch(opts *LdapOpts, searchExpression string, returnFields []string) (*ldap.SearchResult, error) {
+	var rootCertPool *x509.CertPool
+	var err error
+	if opts.CertFile != "" {
+		rootCertPool, err = certPoolFromFile(opts.CertFile)
+		if err != nil {
+			return nil, fmt.Errorf("could not create cert pool from file: %w", err)
+		}
+	}
+
+	dialOpts := ldap.DialWithTLSConfig(
+		&tls.Config{
+			InsecureSkipVerify: opts.Insecure,
+			RootCAs:            rootCertPool,
+		},
+	)
+	conn, err := ldap.DialURL(opts.ServerUrl, dialOpts)
+	if err != nil {
+		return nil, fmt.Errorf("could not connect to LDAP server: %w", err)
+	}
+	defer conn.Close()
+	err = conn.Bind(opts.Username, opts.Password)
+	if err != nil {
+		return nil, fmt.Errorf("could not bind on LDAP server: %w", err)
+	}
+
+	// Prototype, just for reference
+	// func NewSearchRequest(
+	//    BaseDN string,
+	//    Scope, DerefAliases, SizeLimit, TimeLimit int,
+	//    TypesOnly bool,
+	//    Filter string,
+	//    Attributes []string,
+	//    Controls []Control,
+	// ) *SearchRequest
+
+	// This EscapeFilter prevents wildcard searches by escaping the asterisk.
+	// We do want to be able to run wildcard searches.
+	// TODO: make your own filter I guess
+	// searchExpression = ldap.EscapeFilter(searchExpression))
+	// In the meanwhile, this is... a little unsafe
+
+	searchReq := ldap.NewSearchRequest(
+		opts.BaseDN,
+		ldap.ScopeWholeSubtree, ldap.NeverDerefAliases, 0, 0, false,
+		searchExpression,
+		returnFields, //empty attributes means all of them
+		[]ldap.Control{},
+	)
+
+	sr, err := conn.SearchWithPaging(searchReq, 1)
+	if err != nil {
+		return nil, fmt.Errorf("failed to search LDAP: %w", err)
+	}
+	return sr, nil
+
+	// E.g. debug print
+	//for _, entry := range sr.Entries {
+	//    fmt.Printf("%s: %v\n", entry.DN, entry.GetAttributeValue("cn"))
+	//}
+
+}

--- a/internal/adhelper/ad_group_mems.go
+++ b/internal/adhelper/ad_group_mems.go
@@ -1,0 +1,63 @@
+package adhelper
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+)
+
+// Returns a slice containing the usernames of members of an AD group.
+func GetADGroupMembers(ldapOpts *LdapOpts, groupname string) ([]string, error) {
+
+	expression := fmt.Sprintf("(&(objectCategory=Group)(cn=%s))", groupname)
+	results, err := RunADSearch(ldapOpts, expression, []string{"member"})
+	if err != nil {
+		return nil, err
+	}
+
+	members := []string{}
+	for _, entry := range results.Entries {
+		for _, memberCN := range entry.GetAttributeValues("member") {
+			membername, err := deCN(memberCN)
+			if err != nil {
+				return nil, err
+			}
+			members = append(members, membername)
+		}
+	}
+
+	return members, nil
+}
+
+func GetADDeptMembers(ldapOpts *LdapOpts, deptName string) ([]string, error) {
+	expression := fmt.Sprintf("(department=%s)", deptName)
+	results, err := RunADSearch(ldapOpts, expression, []string{"cn"})
+	if err != nil {
+		return nil, err
+	}
+
+	members := []string{}
+	for _, entry := range results.Entries {
+		for _, memberCN := range entry.GetAttributeValues("cn") {
+			membername, err := deCN(memberCN)
+			if err != nil {
+				return nil, err
+			}
+			members = append(members, membername)
+		}
+	}
+
+	return members, nil
+}
+
+// In theory this should match any AD Canonical Name (CN) with a submatch of just the non-canonical name.
+var CNre = regexp.MustCompile(`[Cc][Nn]=([A-Za-z0-9]+)(?:,[Oo][Uu]=[A-Za-z0-9-]+)*(?:,[Dd][Cc]=[A-Za-z0-9-]+)*`)
+
+// Gets just the actual name from a full CN returned from AD.
+func deCN(s string) (string, error) {
+	matches := CNre.FindStringSubmatch(s)
+	if matches == nil {
+		return "", errors.New("attempted to deCN something that didn't seem to be a CN")
+	}
+	return matches[1], nil
+}

--- a/internal/adhelper/cert_pool.go
+++ b/internal/adhelper/cert_pool.go
@@ -1,0 +1,21 @@
+package adhelper
+
+import (
+	"crypto/x509"
+	"fmt"
+	"os"
+)
+
+func certPoolFromFile(filename string) (*x509.CertPool, error) {
+	certPEM, err := os.ReadFile(filename)
+	if err != nil {
+		return nil, fmt.Errorf("could not read cert file: %w", err)
+	}
+	pool := x509.NewCertPool()
+	ok := pool.AppendCertsFromPEM([]byte(certPEM))
+	if !ok {
+		return nil, fmt.Errorf("failed to parse certificate in %s", filename)
+	}
+
+	return pool, nil
+}


### PR DESCRIPTION
dinf is a lot like the adname script -- it runs searches in LDAP with a more convenient interface than ldapsearch.

The adhelper internal package hopefully makes it easier for other tools to do searches like this, aimed at our Active Directory system but not really specific to it.